### PR TITLE
fix: Update media cleanup cron job interval from 15 minutes to 24 hours

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	StartMediaCleanupCron(db, cacheService, logger.Log)
 
-	containerDI, err := container.InitializeContainer(&cfg, db, logger.Log, redisClient, 15*time.Minute, asynqClient)
+	containerDI, err := container.InitializeContainer(&cfg, db, logger.Log, redisClient, 24*time.Hour, asynqClient)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This pull request makes a small but impactful change to the initialization of the dependency injection container in the `backend/cmd/server/main.go` file. The timeout parameter for the `InitializeContainer` function has been increased from 15 minutes to 24 hours.

* [`backend/cmd/server/main.go`](diffhunk://#diff-2074e8c0103565d3d16275fe3ce1e98a4a567b910968e57c8410292d526ac408L140-R140): Updated the timeout parameter in the `InitializeContainer` function from `15*time.Minute` to `24*time.Hour`, likely to accommodate longer-running processes or reduce frequent reinitializations.