### PR TITLE
Fix/can not click popular post

### DIFF
--- a/frontend/app/components/Layout.tsx
+++ b/frontend/app/components/Layout.tsx
@@ -8,7 +8,7 @@ import Link from "next/link";
 import axios from "axios";
 import Script from "next/script";
 import { AuthContext } from "../contexts/authContext";
-import { ChevronDown, LogOut, Notebook, Settings, SquarePen, User, UserCircle } from "lucide-react";
+import { ChevronDown, LogOut, Notebook, SquarePen, User, UserCircle } from "lucide-react";
 import { getnerateId } from "@/lib/utils";
 import { FiCode, FiCpu } from "react-icons/fi";
 import { Button } from "@/components/ui/button";
@@ -240,16 +240,6 @@ export default function Layout({ children }: { children: ReactNode }) {
                           </Link>
                         </DropdownMenuItem>
                         
-                        <DropdownMenuItem asChild>
-                          <Link
-                            href="/settings"
-                            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-all duration-200 text-gray-400 dark:text-gray-600 cursor-not-allowed group"
-                            onClick={(e) => e.preventDefault()}
-                          >
-                            <Settings className="w-5 h-5 text-purple-400 group-hover:scale-110 transition-transform" />
-                            <span className="font-medium">Settings (Coming soon)</span>
-                          </Link>
-                        </DropdownMenuItem>
                         
                         <DropdownMenuSeparator />
                         
@@ -299,18 +289,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                               onClick={(e) => e.preventDefault()}
                             >
                               <UserCircle className="w-5 h-5 text-green-400 group-hover:scale-110 transition-transform" />
-                              <span className="font-medium">Profile (Coming soon)</span>
-                            </Link>
-                          </DropdownMenuItem>
-                          
-                          <DropdownMenuItem asChild>
-                            <Link
-                              href="/settings"
-                              className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-all duration-200 text-gray-400 dark:text-gray-600 cursor-not-allowed group"
-                              onClick={(e) => e.preventDefault()}
-                            >
-                              <Settings className="w-5 h-5 text-purple-400 group-hover:scale-110 transition-transform" />
-                              <span className="font-medium">Settings (Coming soon)</span>
+                              <span className="font-medium">Profile</span>
                             </Link>
                           </DropdownMenuItem>
                         </div>
@@ -410,16 +389,6 @@ export default function Layout({ children }: { children: ReactNode }) {
                           </Link>
                         </DropdownMenuItem>
                         
-                        <DropdownMenuItem asChild>
-                          <Link
-                            href="/settings"
-                            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-all duration-200 text-gray-400 dark:text-gray-600 cursor-not-allowed group"
-                            onClick={(e) => e.preventDefault()}
-                          >
-                            <Settings className="w-5 h-5 text-purple-400 group-hover:scale-110 transition-transform" />
-                            <span className="font-medium">Settings (Coming soon)</span>
-                          </Link>
-                        </DropdownMenuItem>
                         
                         <DropdownMenuSeparator />
                         
@@ -469,18 +438,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                               onClick={(e) => e.preventDefault()}
                             >
                               <UserCircle className="w-5 h-5 text-green-400 group-hover:scale-110 transition-transform" />
-                              <span className="font-medium">Profile (Coming soon)</span>
-                            </Link>
-                          </DropdownMenuItem>
-                          
-                          <DropdownMenuItem asChild>
-                            <Link
-                              href="/settings"
-                              className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-all duration-200 text-gray-400 dark:text-gray-600 cursor-not-allowed group"
-                              onClick={(e) => e.preventDefault()}
-                            >
-                              <Settings className="w-5 h-5 text-purple-400 group-hover:scale-110 transition-transform" />
-                              <span className="font-medium">Settings (Coming soon)</span>
+                              <span className="font-medium">Profile</span>
                             </Link>
                           </DropdownMenuItem>
                         </div>

--- a/frontend/app/home/home-client.tsx
+++ b/frontend/app/home/home-client.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import { useEffect, useState, useRef, useCallback } from "react";
+import Link from "next/link";
 import { Meta } from "../interfaces";
 import BlogCard from "../components/Blog";
 import { Post } from "../interfaces";
@@ -329,10 +330,14 @@ export default function HomePageClient({
                     </div>
                   ))}
                 </div>
-              ) : (
+              ) : popularPosts && popularPosts.length > 0 ? (
                 <div className="space-y-4">
                   {popularPosts.slice(0, 10).map((post, index) => (
-                    <div key={post.id} className="group cursor-pointer bg-slate-800/50 backdrop-blur-sm rounded-lg p-4 border border-slate-700/30 hover:border-slate-600/50 transition-all duration-300">
+                    <Link 
+                      key={post.id} 
+                      href={`/posts/@${post.author?.username}/${post.slug}`}
+                      className="group cursor-pointer bg-slate-800/50 backdrop-blur-sm rounded-lg p-4 border border-slate-700/30 hover:border-slate-600/50 transition-all duration-300 block"
+                    >
                       <div className="flex items-start space-x-3">
                         <div className="flex-1 min-w-0">
                           <h3 className="text-sm font-medium text-gray-900 dark:text-white group-hover:text-orange-600 dark:group-hover:text-orange-400 transition-colors duration-200 line-clamp-2 mb-2">
@@ -364,8 +369,12 @@ export default function HomePageClient({
                           </div>
                         </div>
                       </div>
-                    </div>
+                    </Link>
                   ))}
+                </div>
+              ) : (
+                <div className="text-center py-8">
+                  <p className="text-slate-400 text-sm">No popular posts available</p>
                 </div>
               )}
             </section>

--- a/frontend/app/posts/[username]/[slug]/post-client.tsx
+++ b/frontend/app/posts/[username]/[slug]/post-client.tsx
@@ -303,7 +303,7 @@ export default function PostClient({ post, isLoadingPost }: PostClientProps) {
             <div className="mt-12 p-6 bg-gray-50 dark:bg-gray-800 rounded-xl">
               <div className="flex items-start gap-4">
                 <div className="w-16 h-16 rounded-full bg-gradient-to-br from-orange-400 to-orange-600 flex items-center justify-center text-white font-bold text-xl">
-                  {metadata.authorImage ? (
+                  {metadata.authorImage && metadata.authorImage !== "/default-avatar.png" ? (
                     <Image
                       src={metadata.authorImage}
                       alt={metadata.author}


### PR DESCRIPTION
This pull request focuses on UI improvements and code cleanup in the frontend, particularly around the layout and post listing components. The most notable changes are the removal of the disabled "Settings" menu item, improvements to the "Profile" menu item, enhancements to the popular posts section, and a minor bug fix in the post author avatar logic.

### Navigation and Layout Improvements
* Removed the "Settings (Coming soon)" menu item from all dropdowns in `Layout.tsx` to clean up the navigation and avoid showing non-functional links. [[1]](diffhunk://#diff-c3c88afffb136a1a3d7063bc0216fa139672da306b7113e30990a1ce7988a686L243-L252) [[2]](diffhunk://#diff-c3c88afffb136a1a3d7063bc0216fa139672da306b7113e30990a1ce7988a686L413-L422)
* Updated the "Profile" menu item to remove the "Coming soon" label, making it appear as a standard menu option. [[1]](diffhunk://#diff-c3c88afffb136a1a3d7063bc0216fa139672da306b7113e30990a1ce7988a686L302-R292) [[2]](diffhunk://#diff-c3c88afffb136a1a3d7063bc0216fa139672da306b7113e30990a1ce7988a686L472-R441)

### Popular Posts Section Enhancements
* Changed the popular posts list in `home-client.tsx` to use `Link` components, making each post clickable and navigable to its detail page.
* Added a user-friendly message ("No popular posts available") when there are no popular posts to display.

### Bug Fixes
* Fixed a bug in `post-client.tsx` to only show the author's image if it is set and not the default avatar, improving avatar display logic. ([frontend/app/posts/[username]/[slug]/post-client.tsxL306-R306](diffhunk://#diff-adcda106deab4b9824265ddf152e670103e43340774389963916a0721df9f592L306-R306))

### Code Cleanup
* Added a missing import for `Link` in `home-client.tsx`.
* Removed the unused `Settings` icon import from `Layout.tsx`.