### PR TITLE
Auto-release workflow using PR body for release notes

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,46 @@
+name: Auto Release on Tag
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get PR body from merged commit
+        id: pr
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sha="${GITHUB_SHA}"
+          pr_json=$(gh api repos/${{ github.repository }}/commits/$sha/pulls -H "Accept: application/vnd.github+json" 2>/dev/null || echo "[]")
+          pr_number=$(echo "$pr_json" | jq -r '.[0].number // empty')
+          if [ -n "$pr_number" ]; then
+            gh api repos/${{ github.repository }}/pulls/$pr_number -H "Accept: application/vnd.github+json" --jq '.body // ""' > pr_body.txt
+          else
+            echo "" > pr_body.txt
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: pr_body.txt
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-beta') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           HEAD_REF="${{ github.event.pull_request.head.ref }}"
           echo "head_ref=$HEAD_REF" >> "$GITHUB_OUTPUT"
-          if [[ "$HEAD_REF" == feature/* || "$HEAD_REF" == feture/* || "$HEAD_REF" == refactor/* ]]; then
+          if [[ "$HEAD_REF" == feature/* || "$HEAD_REF" == feture/* || "$HEAD_REF" == refactor/* || "$HEAD_REF" == chore/* ]]; then
             echo "type=minor" >> "$GITHUB_OUTPUT"
           elif [[ "$HEAD_REF" == fix/* ]]; then
             echo "type=patch" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate releases whenever a new tag is pushed that matches the pattern `v*`. The workflow checks out the repository, retrieves the pull request body associated with the tagged commit (if available), and creates a GitHub release using this information as the release notes.

**Automated release workflow:**

* Added a new workflow file `.github/workflows/auto-release.yml` that triggers on tag pushes matching `v*`, checks out the repository, fetches the associated pull request body, and creates a GitHub release with the tag name and PR body as the release notes.