### PR TITLE
Fix/disable codeblock scroll preview

### DIFF
--- a/frontend/app/components/tiptap-templates/simple/view-editor.tsx
+++ b/frontend/app/components/tiptap-templates/simple/view-editor.tsx
@@ -79,7 +79,7 @@ export function PreviewEditor({ content }: PreviewEditorProps) {
   }
 
   return (
-    <div className="w-full h-full flex flex-col items-center justify-center">
+    <div className="preview-editor w-full h-full flex flex-col items-center justify-center">
       <div className="transition-all rounded-md duration-300 max-w-screen-xl w-full ease-out sticky top-16 bg-white dark:bg-gray-900">
         <EditorContent editor={editor} />
       </div>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -888,6 +888,31 @@ td {
   color: inherit;
 }
 
+/* === Preview Editor: disable horizontal scrollbars on code blocks (mobile) === */
+@media (max-width: 640px) {
+  .preview-editor .code-block-content {
+    overflow-x: hidden;
+  }
+
+  .preview-editor .code-block-content pre {
+    white-space: pre-wrap; /* wrap long lines */
+    word-break: break-word;
+    overflow-x: hidden;
+  }
+
+  .preview-editor .code-block-content code,
+  .preview-editor .code-block-content .hljs {
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  /* Hide potential native horizontal scrollbar in WebKit */
+  .preview-editor .code-block-content::-webkit-scrollbar:horizontal {
+    display: none;
+    height: 0 !important;
+  }
+}
+
 /* 📝 Line Clamp Utilities */
 .line-clamp-2 {
   display: -webkit-box;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -913,6 +913,31 @@ td {
   }
 }
 
+/* === Preview Editor: remove code block scrollbars and wrap lines (all viewports) === */
+.preview-editor .code-block-content {
+  overflow: visible;
+  -ms-overflow-style: none; /* IE/Edge */
+  scrollbar-width: none; /* Firefox */
+}
+
+.preview-editor .code-block-content::-webkit-scrollbar {
+  display: none;
+  width: 0 !important;
+  height: 0 !important;
+}
+
+.preview-editor pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: visible !important; /* override global overflow-x-auto */
+}
+
+.preview-editor .hljs {
+  overflow: visible !important; /* override highlight.js rule */
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* 📝 Line Clamp Utilities */
 .line-clamp-2 {
   display: -webkit-box;


### PR DESCRIPTION
This pull request improves the display of code blocks within the preview editor, especially on mobile devices, by removing horizontal scrollbars and ensuring long lines wrap properly. The changes include both CSS adjustments and a minor update to the preview editor's container class.

**Preview editor styling improvements:**

* Added the `preview-editor` class to the main container in `PreviewEditor` to enable targeted styling.

**Code block display enhancements:**

* Updated `globals.css` to remove horizontal scrollbars and force line wrapping for code blocks in the preview editor across all viewports, with additional tweaks for mobile devices. This includes hiding native scrollbars, setting `white-space: pre-wrap`, and ensuring word breaks for long lines.