### PR TITLE
refactor: remove Python extractor service from Docker Compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,14 +57,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  extractor:
-    build:
-      context: ./extractor
-      dockerfile: Dockerfile
-    container_name: dev-blog-extractor-python-app
-    restart: always
-    ports:
-      - "5002:5002"
 
 volumes:
   postgres_data:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,16 +71,6 @@ services:
     networks:
       - public
 
-  extractor:
-    build:
-      context: ./extractor
-      dockerfile: Dockerfile
-    container_name: blog-extractor-python-app
-    restart: always
-    ports:
-      - "127.0.0.1:5002:5002"
-    networks:
-      - internal
 
 volumes:
   postgres_data:


### PR DESCRIPTION
- Remove extractor service from docker-compose.dev.yml
- Remove extractor service from docker-compose.prod.yml
- Clean up deployment configuration