### PR TITLE
Add LinkPreviewNode to HTML generation

### DIFF
--- a/frontend/app/components/tiptap-templates/simple/generate-html.tsx
+++ b/frontend/app/components/tiptap-templates/simple/generate-html.tsx
@@ -15,6 +15,7 @@ import { Link } from "@/app/components/tiptap-extension/link-extension"
 import { Selection } from "@/app/components/tiptap-extension/selection-extension"
 import { TrailingNode } from "@/app/components/tiptap-extension/trailing-node-extension"
 import { ImageUploadNode } from "@/app/components/tiptap-node/image-upload-node/image-upload-node-extension"
+import { LinkPreviewNode } from "@/app/components/tiptap-node/link-preview-node/link-preview-node-extension"
 
 import { JSONContent } from "@tiptap/react"
 
@@ -50,6 +51,7 @@ export function generateHtmlFromContent(content: JSONContent): string {
     Selection,
     TrailingNode,
     ImageUploadNode,
+    LinkPreviewNode,
     Link,
   ])
 }


### PR DESCRIPTION
This pull request introduces support for the `LinkPreviewNode` extension in the Tiptap editor's HTML generation pipeline. This allows content containing link previews to be properly processed and rendered as HTML.

Enhancement to Tiptap HTML generation:

* Added the `LinkPreviewNode` extension to the imports and the list of active extensions in the `generateHtmlFromContent` function, enabling HTML generation for link preview nodes. [[1]](diffhunk://#diff-3e89f776a6a142a0e025c20594b9699c95d9e17e73fd228a33aed5b72412b2fcR18) [[2]](diffhunk://#diff-3e89f776a6a142a0e025c20594b9699c95d9e17e73fd228a33aed5b72412b2fcR54)


#55 