### PR TITLE
fix: publish posts without server AI moderation

### DIFF
--- a/backend/api/v1/post/router.go
+++ b/backend/api/v1/post/router.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"rag-searchbot-backend/internal/container"
 	"rag-searchbot-backend/internal/middleware"
-	"rag-searchbot-backend/internal/notification"
 	"rag-searchbot-backend/internal/post"
 
 	"github.com/gin-gonic/gin"
@@ -24,20 +23,11 @@ func RegisterRoutes(router *gin.RouterGroup, container *container.Container, mux
 		container.Log,
 	)
 
-	// Worker Setup
-	worker := post.FilterPostWorker{
-		Logger:      container.Log,
-		PostRepo:    container.PostRepo,
-		QueueRepo:   container.QueueRepo,
-		NotiService: container.NotificationService.(*notification.NotificationService),
-	}
-
 	// Create Service + Handler
 	taskEnqueuer := post.NewTaskEnqueuer(container.AsynqClient, container.QueueRepo)
 	postService := post.NewPostService(container.PostRepo, container.MediaService, taskEnqueuer)
 
-	mux.HandleFunc(post.TaskTypeFilterPostContentByAI, post.FilterPostContentByAIWorkerHandler(worker))
-
+	// AI moderation is disabled; publishing is handled synchronously after auth.
 	ps, ok := postService.(*post.PostService)
 	if !ok {
 		log.Fatal("[FATAL] Failed to cast postService to *post.PostService")

--- a/backend/internal/post/service.go
+++ b/backend/internal/post/service.go
@@ -9,6 +9,7 @@ import (
 	"rag-searchbot-backend/internal/models"
 	"rag-searchbot-backend/pkg/errs"
 	"rag-searchbot-backend/pkg/logger"
+	"rag-searchbot-backend/pkg/tiptap"
 	"strconv"
 	"time"
 
@@ -349,22 +350,22 @@ func (s *PostService) PublishPost(post *PublishPostRequestDTO, user *models.User
 	existingPost.Description = post.Description
 	existingPost.Thumbnail = post.Thumbnail
 	existingPost.HTMLContent = post.HTMLContent
-	existingPost.Published = false
-	existingPost.Status = models.PostProcessing
-	existingPost.PublishedAt = nil
+	existingPost.Published = true
+	existingPost.Status = models.PostPublished
+	now := time.Now()
+	existingPost.PublishedAt = &now
+	if post.HTMLContent != nil {
+		existingPost.ReadTime = float64(tiptap.EstimateReadTimeFromHTML(*post.HTMLContent))
+	}
 
 	// delete existing embedding from vector db
 	s.Repo.DeleteEmbeddingsByPostID(existingPost.ID.String())
 
-	logger.Log.Info("Enqueuing post content for AI filtering ",
+	logger.Log.Info("Publishing post without server-side AI moderation",
 		zap.String("post_id", existingPost.ID.String()),
 		zap.String("post_title", existingPost.Title),
 		zap.String("author_id", existingPost.AuthorID.String()),
 		zap.String("author_email", user.Email))
-	_, err = s.TaskEnqueuer.EnqueueFilterPostContentByAI(existingPost, user)
-	if err != nil {
-		return err
-	}
 
 	return s.Repo.Update(existingPost)
 }

--- a/backend/internal/post/tests/service_test.go
+++ b/backend/internal/post/tests/service_test.go
@@ -8,10 +8,12 @@ import (
 	"rag-searchbot-backend/internal/media"
 	"rag-searchbot-backend/internal/models"
 	"rag-searchbot-backend/internal/post"
+	"rag-searchbot-backend/pkg/logger"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -41,6 +43,9 @@ func (m *MockPostRepository) GetByID(id string) (*models.Post, error) {
 }
 func (m *MockPostRepository) GetBySlug(slug string) (*models.Post, error) {
 	args := m.Called(slug)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*models.Post), args.Error(1)
 }
 func (m *MockPostRepository) Update(post *models.Post) error {
@@ -146,6 +151,40 @@ func (m *MockMediaService) UploadToChibisafe(fileHeader *multipart.FileHeader) (
 
 // Mock for TaskEnqueuer (minimal for this test)
 type MockTaskEnqueuer struct{}
+
+func TestPublishPostPublishesWithoutAIReview(t *testing.T) {
+	logger.Log = zap.NewNop()
+	repo := new(MockPostRepository)
+	media := new(MockMediaService)
+	user := &models.User{ID: uuid.New(), Email: "writer@example.com"}
+	shortSlug := "hello-world"
+	existing := &models.Post{
+		ID:        uuid.New(),
+		Slug:      shortSlug + "-" + user.ID.String(),
+		ShortSlug: shortSlug + "-" + user.ID.String(),
+		AuthorID:  user.ID,
+	}
+	html := "<p>Hello world</p>"
+
+	repo.On("GetByShortSlug", existing.ShortSlug).Return(existing, nil)
+	repo.On("GetBySlug", "hello-world").Return(nil, gorm.ErrRecordNotFound)
+	repo.On("DeleteEmbeddingsByPostID", existing.ID.String()).Return(nil)
+	repo.On("Update", existing).Return(nil)
+
+	service := post.NewPostService(repo, media, &post.TaskEnqueuer{}).(*post.PostService)
+	err := service.PublishPost(&post.PublishPostRequestDTO{
+		Slug:        "hello-world",
+		Title:       "Hello world",
+		HTMLContent: &html,
+	}, user, shortSlug)
+
+	assert.NoError(t, err)
+	assert.True(t, existing.Published)
+	assert.Equal(t, models.PostPublished, existing.Status)
+	assert.NotNil(t, existing.PublishedAt)
+	assert.Equal(t, 1.0, existing.ReadTime)
+	repo.AssertExpectations(t)
+}
 
 func TestCreatePost_UpdateExisting(t *testing.T) {
 	repo := new(MockPostRepository)

--- a/frontend/app/w/[slug]/page.tsx
+++ b/frontend/app/w/[slug]/page.tsx
@@ -155,7 +155,6 @@ export default function EditPost() {
         const htmlContent = generateHtmlFromContent(contentState);
 
         try {
-            // Send to AI for review - status becomes PROCESSING
             const response = await axiosInstance.put(`posts/publish/${slug}`, {
                 slug: metadata.slug || generateSlug(metadata.title),
                 title: metadata.title,
@@ -165,14 +164,13 @@ export default function EditPost() {
             });
 
 
-            // Update post status to PROCESSING
-            setPost((prev: Post | null) => prev ? { ...prev, status: 'PROCESSING' } : null);
+            setPost((prev: Post | null) => prev ? { ...prev, status: 'PUBLISHED', published: true } : null);
             setPublishStatus('published');
             setShowPublishModal(false);
 
             toast({
-                title: 'Sent for Review',
-                description: 'Your content has been sent to AI for review and will be published once approved.',
+                title: 'Published Successfully',
+                description: 'Your content is now live.',
             });
 
             setTimeout(() => {
@@ -183,7 +181,7 @@ export default function EditPost() {
             console.error('Publish failed:', error);
             toast({
                 title: 'Publish Failed',
-                description: 'There was an error sending your content for review. Please try again.',
+                description: 'There was an error publishing your content. Please try again.',
                 variant: 'destructive',
             });
         }


### PR DESCRIPTION
## Summary

- Publish posts immediately after authentication without server-side AI moderation.
- Stop registering the moderation worker that depends on the revoked LLM token.
- Update the editor UI and add a regression test for the new publish flow.

## Why

The previous flow queued every publish for AI review, leaving posts in PROCESSING when the server-side LLM credential was revoked. Authentication is still required to publish.

## Validation

- Docker Go tests for post service and router: passed
- git diff --check: passed
- Frontend type-check was attempted; the repository currently has a baseline missing module frontend/public/logo.svg, and frozen install reports an existing pnpm lockfile mismatch.