### PR TITLE
fix: pin pnpm for production builds

### DIFF
--- a/frontend/Dockerfile.prod
+++ b/frontend/Dockerfile.prod
@@ -2,7 +2,7 @@
 FROM node:22.22.0
 
 # 2. Install pnpm
-RUN npm install -g pnpm
+RUN npm install -g pnpm@10.14.0
 
 # 3. Set working directory
 WORKDIR /bsoblog-prod


### PR DESCRIPTION
## Summary
- Pin the production Docker build to pnpm 10.14.0.
- Avoid pnpm 11 interactive build-script approval failures in non-interactive Docker builds.

## Root cause
The unpinned `npm install -g pnpm` now installs pnpm 11, which exits with `ERR_PNPM_IGNORED_BUILDS` after installing dependencies.

## Validation
- pnpm 10.14.0 install verified in the Node 22.22.0 image
- Frontend frozen install and production build passed locally
- Jest: 2 suites, 7 tests passed

## Deploy
After merge, run `git pull --ff-only origin master` and `docker compose -f docker-compose.prod.yml up -d --build` on the server. Do not use `down -v`.