### PR TITLE
fix(deps): bump handlebars to 4.7.9 in npm lockfile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8580,9 +8580,9 @@
       "license": "MIT"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Bumps `handlebars` 4.7.8 → 4.7.9 in `frontend/package-lock.json` (npm staging lockfile).

Resolves **7 dev-scoped Dependabot alerts** (1 critical, 3 high, 2 medium, 1 low) covering Handlebars JS-injection / prototype-pollution / `__lookupSetter__` bypass advisories. handlebars is a dev-only transitive of `ts-jest` (`^4.7.8`); `4.7.9` satisfies that range and is the patched release.

`npm audit` after the bump: **1 low** (quill 2.0.3 — no patched release exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)